### PR TITLE
Added a TNEFSignatureError class to allow the TNEF class to throw an exception

### DIFF
--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -3,7 +3,7 @@ import sys, argparse, logging
 logging.basicConfig()
 logging.root.setLevel(logging.ERROR)
 
-from tnef import TNEF, TNEFAttachment, TNEFObject
+from tnef import TNEF, TNEFAttachment, TNEFObject, TNEFSignatureError
 from mapi import TNEFMAPI_Attribute
 
 
@@ -46,7 +46,10 @@ def tnefparse():
       logging.root.setLevel(level)
 
    for tfp in args.file[0]:
-      t = TNEF(tfp.read(), do_checksum=args.checksum)
+      try:
+         t = TNEF(tfp.read(), do_checksum=args.checksum)
+      except TNEFSignatureError, e:
+         sys.exit(e.message)
       if args.overview:
          print("\nOverview of %s: \n" % tfp.name)
 

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -196,7 +196,7 @@ class TNEF:
    def __init__(self, data, do_checksum = True):
       self.signature = bytes_to_int(data[0:4])
       if self.signature != TNEF.TNEF_SIGNATURE:
-         sys.exit("Wrong TNEF signature: 0x%2.8x" % self.signature)
+         raise TNEFSignatureError("Wrong TNEF signature: 0x%2.8x" % self.signature, self.signature)
       self.key = bytes_to_int(data[4:6])
       self.objects = []
       self.attachments = []
@@ -270,3 +270,12 @@ def to_zip(data, default_name='no-name', deflate=True):
 
    # Return the binary data for the zip file
    return sfp.getvalue()
+
+
+class TNEFSignatureError(Exception):
+    
+    def __init__(self, message, signature):
+
+        Exception.__init__(self, message)
+
+        self.signature = signature


### PR DESCRIPTION
Added a TNEFSignatureError class to allow the TNEF class to throw an exception, and not call sys.exit when used as a library.

cmdline.py is modified to try/except on this exception and exit with
the previous behaviour.
