### PR TITLE
missing import os

### DIFF
--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -1,6 +1,6 @@
 """extracts TNEF encoded content from for example winmail.dat attachments.
 """
-import sys, logging
+import sys, logging, os
 
 logger = logging.getLogger("tnef-decode")
 


### PR DESCRIPTION
File "/tnefparse/tnef.py", line 255, in to_zip
    root, ext = os.path.splitext(filename)
NameError: global name 'os' is not defined