### PR TITLE
s/sys.exit()/raise ValueError/.

### DIFF
--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -1,6 +1,6 @@
 """extracts TNEF encoded content from for example winmail.dat attachments.
 """
-import sys, logging, os
+import logging, os
 
 logger = logging.getLogger("tnef-decode")
 
@@ -196,7 +196,7 @@ class TNEF:
    def __init__(self, data, do_checksum = True):
       self.signature = bytes_to_int(data[0:4])
       if self.signature != TNEF.TNEF_SIGNATURE:
-         sys.exit("Wrong TNEF signature: 0x%2.8x" % self.signature)
+         raise ValueError("Wrong TNEF signature: 0x%2.8x" % self.signature)
       self.key = bytes_to_int(data[4:6])
       self.objects = []
       self.attachments = []


### PR DESCRIPTION
It's bad practice to call sys.exit() from a library.