### PR TITLE
Remove basicLogger singleton

### DIFF
--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -3,7 +3,6 @@
 import logging
 from .util import bytes_to_int
 
-logging.basicConfig()
 logger = logging.getLogger("mapi-decode")
 
 SZMAPI_UNSPECIFIED    = 0x0000 # MAPI Unspecified


### PR DESCRIPTION
Instantiating a new logger is not required and causes issues when using as a python module since logs will be generated twice