### PR TITLE
Add optimisation from pull  #15 and fix long_filename() function

### DIFF
--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -78,7 +78,7 @@ def decode_mapi(data):
             attr_data = []
             for j in range(num_vals):
                # inlined version of bytes_to_int, for performance:
-               length = ord(offset[0]) + (ord(offset[1]) << 8) + (ord(offset[2]) << 16) + (ord(offset[3]) << 24)
+               length = ord(data[offset]) + (ord(data[offset + 1]) << 8) + (ord(data[offset + 2]) << 16) + (ord(data[offset + 3]) << 24)
                offset += 4
                q,r = divmod(length, 4)
                if r != 0:

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -93,20 +93,6 @@ class TNEFAttachment(object):
             break
 
       if attr is not None:
-         fn = str(attr.data).replace('0','')
-      else:
-         fn = self.name
-
-      return fn.split('\\')[-1]
-
-   def display_name(self):
-      atname = TNEFMAPI_Attribute.MAPI_DISPLAY_NAME
-      attr = None
-      for a in self.mapi_attrs:
-         if a.name == atname:
-            attr = a
-            break
-      if attr is not None:
          fn = attr.data[0][:-1]
       else:
          fn = self.name

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -99,6 +99,18 @@ class TNEFAttachment(object):
 
       return fn.split('\\')[-1]
 
+   def display_name(self):
+      atname = TNEFMAPI_Attribute.MAPI_DISPLAY_NAME
+      attr = None
+      for a in self.mapi_attrs:
+         if a.name == atname:
+            attr = a
+            break
+      if attr is not None:
+         fn = attr.data[0][:-1]
+      else:
+         fn = self.name
+      return fn
 
    def add_attr(self, attribute):
       logger.debug("Attachment attr name: 0x%4.4x" % attribute.name)


### PR DESCRIPTION
The actual problem is that tnefparse can't get the full name of the attachments from inside.

Without the fix:
```sh
>>> import tnefparse
>>> for attachment in tnefparse.tnef.TNEF(open("/tmp/winmail.dat", "rb").read()).attachments:
...     print "%s -> %s" % (attachment.name, attachment.long_filename())
... 
No handlers could be found for logger "tnef-decode"
299BKP~1.PDF -> 299BKP~1.PDF
NPK_TE~1.MSI -> NPK_TE~1.MSI
SIA451.01S -> SIA451.01S
image001.png -> image001.png
```
With the fix:
```sh
>>> for attachment in tnefparse.tnef.TNEF(open("/tmp/winmail.dat", "rb").read()).attachments:
...     print "%s -> %s" % (attachment.name, attachment.long_filename())
... 
299BKP~1.PDF -> 299 BKP 211 Angebotsformular Baumeister H1.pdf
NPK_TE~1.MSI -> NPK_Texte.MSIA
SIA451.01S -> SIA451.01S
image001.png -> image001.png
```

