### PR TITLE
Made it so long filenames work in Python 3

### DIFF
--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -78,7 +78,10 @@ def decode_mapi(data):
             attr_data = []
             for j in range(num_vals):
                # inlined version of bytes_to_int, for performance:
-               length = ord(data[offset]) + (ord(data[offset + 1]) << 8) + (ord(data[offset + 2]) << 16) + (ord(data[offset + 3]) << 24)
+               if isinstance(data, str):
+                  length = ord(data[offset]) + (ord(data[offset + 1]) << 8) + (ord(data[offset + 2]) << 16) + (ord(data[offset + 3]) << 24)
+               else:
+                  length = data[offset] + (data[offset + 1] << 8) + (data[offset + 2] << 16) + (data[offset + 3] << 24)
                offset += 4
                q,r = divmod(length, 4)
                if r != 0:

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -94,7 +94,7 @@ class TNEFAttachment(object):
             break
 
       if attr is not None:
-         fn = attr.data[0].rstrip('\x00')
+         fn = attr.data[0].decode().rstrip('\x00')
       else:
          fn = self.name
 


### PR DESCRIPTION
There might be a more elegant way to do this.