### PR TITLE
Fix inline bytes_to_int for py3

### DIFF
--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -1,5 +1,6 @@
 "MAPI attribute definitions"
 
+import struct
 import sys
 import logging
 from .util import bytes_to_int
@@ -80,9 +81,10 @@ def decode_mapi(data):
 
 #            logger.debug("Number of values: %i" % num_vals)
             attr_data = []
+            unpack_int = struct.Struct('<I').unpack
             for j in range(num_vals):
                # inlined version of bytes_to_int, for performance:
-               length = ord(data[offset]) + (ord(data[offset + 1]) << 8) + (ord(data[offset + 2]) << 16) + (ord(data[offset + 3]) << 24)
+               length = unpack_int(data[offset : offset + 4])[0]
                offset += 4
                q,r = divmod(length, 4)
                if r != 0:

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -94,7 +94,7 @@ class TNEFAttachment(object):
             break
 
       if attr is not None:
-         fn = attr.data[0].rstrip('\x00')
+         fn = attr.data[0].rstrip(b'\x00')
       else:
          fn = self.name
 


### PR DESCRIPTION
The inlining of bytes_to_int in decode_mapi used the py2 version, not py3. I've switched it to use a struct based method which is both fast and supported by both py2 and py3. 

We should consider using struct more broadly, but it requires the integer size to be known in advance to be fast. We could have separate functions for each byte -> int sizes.