### PR TITLE
Decode body strings if we have mapi codepage values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ found inside them and so on::
    -rb, --rtfbody         extract the RTF body to stdout
    -l LEVEL, --log LEVEL  set log level to DEBUG, INFO, WARN or ERROR
    -c, --checksum         calculate checksums (off by default)
+   -d, --dump             extract a json dump of the tnef contents
 
 The library can also be used as a basis for applications that need to parse TNEF. To parse a TNEF attachment, run eg. :
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import tempfile
 
@@ -55,3 +56,11 @@ def test_cmdline_rtfbody(script_runner):
     assert len(ret.stdout) == 593
     assert ret.stderr == ''
     assert ret.success
+
+
+def test_dump(script_runner):
+    ret = script_runner.run('tnefparse', '-d', 'tests/examples/two-files.tnef')
+    assert ret.success
+    dump = json.loads(ret.stdout)
+    assert sorted(list(dump.keys())) == [u'attachments', u'attributes', u'extended_attributes']
+    assert len(dump['attachments']) == 2

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -108,6 +108,9 @@ def test_decode(tnefspec):
         if objs:
             assert objcodes(t) == objs, "wrong objs: %s" % ["0x%2.2x" % o.name for o in t.objects]
 
+        assert t.dump(True)
+        assert t.dump(False)
+
 
 def test_zip():
     with open(datadir + os.sep + 'one-file.tnef', "rb") as tfile:

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -75,9 +75,16 @@ def test_decode(tnefspec):
     with open(datadir + os.sep + fn, "rb") as tfile:
         t = TNEF(tfile.read())
         assert t.key == key, "wrong key: 0x%2.2x" % t.key
-        assert [a.long_filename() for a in t.attachments] == attchs
+
         for m in t.mapiprops:
+            assert m.__str__()
             assert m.data is not None
+
+        for i, a in enumerate(t.attachments):
+            assert a.long_filename() == attchs[i]
+            for m in a.mapi_attrs:
+                assert m.__str__()
+                assert m.data is not None
 
         if t.htmlbody:
             assert b'html' in t.htmlbody

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -3,7 +3,8 @@ import os
 import tempfile
 
 from tnefparse import TNEF
-from tnefparse.tnef import to_zip, TNEFMAPI_Attribute
+from tnefparse.tnef import to_zip
+from tnefparse.mapi import TNEFMAPI_Attribute
 
 logging.basicConfig()
 datadir = os.path.dirname(os.path.realpath(__file__)) + os.sep + "examples"
@@ -93,7 +94,7 @@ def test_decode(tnefspec):
                     assert isinstance(n_m, TNEFMAPI_Attribute)
 
         if t.htmlbody:
-            assert b'html' in t.htmlbody
+            assert 'html' in t.htmlbody
 
         if body:
             assert getattr(t, body)

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -3,11 +3,9 @@ import os
 import tempfile
 
 from tnefparse import TNEF
-from tnefparse.tnef import to_zip
+from tnefparse.tnef import to_zip, TNEFMAPI_Attribute
 
 logging.basicConfig()
-
-
 datadir = os.path.dirname(os.path.realpath(__file__)) + os.sep + "examples"
 
 SPECS = (
@@ -60,14 +58,15 @@ SPECS = (
    ("bad_checksum.tnef", 0x5784, ['image001.png'], 'body', []),
 )
 
+
 # generate tests for all example files
 def pytest_generate_tests(metafunc):
     if "tnefspec" in metafunc.funcargnames:
         metafunc.parametrize("tnefspec", SPECS, ids=[s[0] for s in SPECS])
 
 
-objnames = lambda t: [TNEF.codes[o.name] for o in t.objects]
-objcodes = lambda t: [o.name for o in t.objects]
+def objcodes(tnef):
+    return [o.name for o in tnef.objects]
 
 
 def test_decode(tnefspec):
@@ -85,6 +84,13 @@ def test_decode(tnefspec):
             for m in a.mapi_attrs:
                 assert m.__str__()
                 assert m.data is not None
+
+        for m in t.msgprops:
+            assert m.__str__()
+            assert m.data is not None
+            if m.name == TNEF.ATTRECIPTABLE:
+                for n_m in m.data[0]:
+                    assert isinstance(n_m, TNEFMAPI_Attribute)
 
         if t.htmlbody:
             assert b'html' in t.htmlbody

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import os
 import sys
@@ -40,6 +41,9 @@ argument('-l', '--logging', choices=["DEBUG", "INFO", "WARN", "ERROR"],
 
 argument('-c', '--checksum', action="store_true", default=False,
          help="calculate checksums (off by default)")
+
+argument('-d', '--dump', action="store_true", default=False,
+         help="extract a json dump of the tnef contents")
 
 
 def tnefparse():

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -66,7 +66,7 @@ def tnefparse():
             # list TNEF attachments
             print("  Attachments:\n")
             for a in t.attachments:
-                print("    " + a.name.decode("utf-8"))
+                print("    " + a.name)
 
             # list TNEF objects
             print("\n  Objects:\n")
@@ -81,10 +81,13 @@ def tnefparse():
                     logging.root.warning("Unknown MAPI Property: %s" % hex(p.name))
             print("")
 
+        elif args.dump:
+            print(json.dumps(t.dump(force_strings=True), sort_keys=True, indent=4))
+
         elif args.attachments:
             pth = args.path.rstrip(os.sep) + os.sep if args.path else ''
             for a in t.attachments:
-                with open(pth + a.name.decode('utf-8'), "wb") as afp:
+                with open(pth + a.name, "wb") as afp:
                     afp.write(a.data)
             sys.stderr.write("Successfully wrote %i files\n" % len(t.attachments))
             sys.exit()

--- a/tnefparse/codepage.py
+++ b/tnefparse/codepage.py
@@ -1,0 +1,34 @@
+# https://docs.microsoft.com/en-us/windows/desktop/intl/code-page-identifiers
+CODEPAGE_MAP = {
+    20127: 'ascii',
+    20866: 'koi8-r',
+    28591: 'iso-8859-1',
+    65001: 'utf-8',
+}
+FALLBACK='cp1252'
+
+
+class Codepage(object):
+    def __init__(self, codepage):
+        self.cp = codepage
+
+    def best_guess(self):
+        if CODEPAGE_MAP.get(self.cp):
+            return CODEPAGE_MAP.get(self.cp)
+        elif self.cp <= 1258:  # max cpXXXX page in python
+            return 'cp%d' % self.cp
+        else:
+            return None
+
+    def codepage(self):
+        bg = self.best_guess()
+        if bg:
+            return bg
+        else:
+            return 'cp%d' % self.cp
+
+    def decode(self, byte_str):
+        if isinstance(byte_str, bytes):
+            return byte_str.decode(self.best_guess() or FALLBACK)
+        else:
+            return byte_str

--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -214,8 +214,11 @@ class TNEFMAPI_Attribute(object):
 
     @property
     def name_str(self):
-        return self.guid_name or TNEFMAPI_Attribute.codes.get(
-            self.name or self.guid_prop, hex(self.guid_prop or self.name)
+        return (
+            self.guid_name or
+            TNEFMAPI_Attribute.codes.get(self.name) or
+            TNEFMAPI_Attribute.codes.get(self.guid_prop) or
+            hex(self.guid_prop or self.name)
         )
 
     def __str__(self):

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -267,7 +267,7 @@ class TNEF(object):
             elif obj.name == TNEF.ATTOEMCODEPAGE:
                 self.codepage = 'cp%d' % uint32(obj.data)
             elif obj.type in (TNEFObject.PTYPE_CLASS, TNEFObject.PTYPE_STRING):
-                obj.data = obj.data.decode(self.codepage)
+                obj.data = obj.data.decode(self.codepage).rstrip('\x00')
                 self.msgprops.append(obj)
             elif obj.name == TNEF.ATTPRIORITY:
                 obj.data = 3 - uint16(obj.data)

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -277,8 +277,8 @@ class TNEF(object):
                 att_offset = 4
                 recipients = []
                 for _ in range(rows):
-                    att_offset, recipients = decode_mapi(obj.data, self.codepage, starting_offset=att_offset)
-                    recipients.append(recipients)
+                    att_offset, recipient = decode_mapi(obj.data, self.codepage, starting_offset=att_offset)
+                    recipients.append(recipient)
                 obj.data = recipients
                 self.msgprops.append(obj)
             elif obj.name == TNEF.ATTFROM:


### PR DESCRIPTION
 - Bugfix: GUID property names are returned in `__str__`
 - Reconcile object and mapi level properties
 - strip trailing `\0` from object level attribute strings
 - Bugfix: prevent recursive addtion of recipient list due to variable name overlap
 - Decode binary body and filenames if we can
 - Add a dump method