### PR TITLE
Parse `TNEF.ATTDATEEND` objects into datetimes

### DIFF
--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -308,7 +308,7 @@ class TNEF(object):
                 obj.data = bytes_to_int(obj.data)
                 self.msgprops.append(obj)
             elif obj.type == TNEFObject.PTYPE_TIME and obj.name in (
-                TNEF.ATTDATESTART, TNEF.ATTDATEMODIFY, TNEF.ATTDATESENT, TNEF.ATTDATERECD
+                TNEF.ATTDATESTART, TNEF.ATTDATEEND, TNEF.ATTDATEMODIFY, TNEF.ATTDATESENT, TNEF.ATTDATERECD
             ):
                 try:
                     obj.data = typtime(obj.data)


### PR DESCRIPTION
Hello,

First of all, thank you for your work, this module is really useful to me !

I noticed that TNEF objects representing the end time of an event where not parsed into datetimes in the TNEF constructor.
I figured this was a slight oversight and added `TNEF.ATTDATEEND` to the list of TNEFObject.name readable as datetimes [here](https://github.com/koodaamo/tnefparse/blob/master/tnefparse/tnef.py#L311)

I hope this helps,

Evomassiny
