### PR TITLE
Add badge for supported Python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,14 @@
 tnefparse - TNEF decoding and attachment extraction
 ===================================================
 
-.. image:: https://badge.fury.io/py/tnefparse.png
-  :target: http://badge.fury.io/py/tnefparse
-
 .. image:: https://travis-ci.org/koodaamo/tnefparse.png?branch=master
   :target: https://travis-ci.org/koodaamo/tnefparse
 
 .. image:: https://codecov.io/gh/koodaamo/tnefparse/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/koodaamo/tnefparse
+
+.. image:: https://img.shields.io/pypi/v/tnefparse.svg
+  :target: https://pypi.org/project/tnefparse/
 
 .. image:: https://img.shields.io/pypi/pyversions/tnefparse.svg
   :target: https://pypi.org/project/tnefparse/

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,16 @@ tnefparse - TNEF decoding and attachment extraction
 ===================================================
 
 .. image:: https://badge.fury.io/py/tnefparse.png
-    :target: http://badge.fury.io/py/tnefparse
+  :target: http://badge.fury.io/py/tnefparse
 
 .. image:: https://travis-ci.org/koodaamo/tnefparse.png?branch=master
-        :target: https://travis-ci.org/koodaamo/tnefparse
+  :target: https://travis-ci.org/koodaamo/tnefparse
 
 .. image:: https://codecov.io/gh/koodaamo/tnefparse/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/koodaamo/tnefparse
+
+.. image:: https://img.shields.io/pypi/pyversions/tnefparse.svg
+  :target: https://pypi.org/project/tnefparse/
 
 This is a pure-python library for decoding Microsoft's Transport Neutral Encapsulation Format (TNEF), for Python
 versions 2.7, 3.5+ and PyPy. For more information on TNEF, see for example 


### PR DESCRIPTION
Also, use PyPi version badge from shields.io, as it it looks a tad better and sharper than the old one.

I generated a preview via `zest.releaser`s `longtest` command - if there is a simpler way - I am always looking forward to learn new things.

![Screenshot from 2020-05-23 15-00-52](https://user-images.githubusercontent.com/9895620/82731325-461ea700-9d06-11ea-93c9-7a96bbedd7b6.png)
