### PR TITLE
Modernize package and test setup

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,6 @@ jobs:
       
     - name: Test with pytest
       run: |
-        pip install -e .
-        pip install compressed_rtf
+        pip install -e .[optional]
         pip install pytest pytest-console-scripts
         pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ python:
   - "pypy"
 
 install:
-  - pip install -e .
-  - pip install pytest pytest-cov pytest-console-scripts codecov compressed_rtf
+  - pip install -U pip
+  - pip install -e .[optional]
+  - pip install pytest pytest-cov pytest-console-scripts codecov
 
 script:
   - pytest --cov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,7 @@ tnefparse 1.3.0 (2018-12-01)
 - add tnefparse -p | --path option for setting attachment extraction path
 - support more MAPI (PidTag) properties (jrideout)
 - support RTF body extraction (jrideout)
-- support extracting top level object attributues in msgprops (jrideout)
+- support extracting top level object attributes in msgprops (jrideout)
 - util.raw_mapi & tnefparse.parseFile functions will be deprecated after 1.3
 
 tnefparse 1.2.3, 2018-11-14

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ tnefparse 1.3.1 (unreleased)
 - heuristics to decode binary body and filenames when possible (jrideout)
 - JSON export for TNEF contents tnefparse (jrideout)
 - add support for Python 3.8 (jugmac00)
+- modernize package and test setup (jugmac00)
 
 tnefparse 1.3.0 (2018-12-01)
 =============================

--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,18 @@ The parsed attachment contents are then available as TNEF object attributes:
 
 Some of the above properties may be empty, depending on what's contained in the attachment that was parsed.
 
-To run the tests, first install the package using e.g. :code:`pip install -e .` and then run :code:`python setup.py test`.
+Tests
+-----
+
+To run the test suite, all you need is tox_. `tox` will run all tests on all supported Python versions.
+
+If you want to run the tests only for e.g. Python 3.8, just enter `tox -e py38`.
+
+Contributing
+------------
 
 Issues and pull requests welcome. **Please however always provide an example TNEF file** that can be used to demonstrate the bug or desired behavior, if at all possible.
 
 **Note: If you have understanding of TNEF and/or MIME internals or just need this package and want to help with maintaining it, I am open to giving you commit rights. Just let me know.**
 
+.. _tox: https://tox.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,11 @@ To run the test suite, all you need is tox_. `tox` will run all tests on all sup
 
 If you want to run the tests only for e.g. Python 3.8, just enter `tox -e py38`.
 
+You also can run a subset of tests in a specific environment by invoking e.g. `tox -e py38 -- -k test_cmdline`.
+
+With `tox -e coverage` you can generate a coverage report.
+The output will be shown in the terminal and a HTML coverage report will be generated in the `htmlcov` directory.
+
 Contributing
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('HISTORY.rst') as history_file:
 
 setup(name='tnefparse',
       version=version,
-      description="a TNEF decoding library written in python, without external dependencies",
+      description="a TNEF decoding library written in Python, without external dependencies",
       long_description=readme + '\n\n' + history,
       classifiers=[
        'Topic :: Communications :: Email',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='tnefparse',
       url='https://github.com/koodaamo/tnefparse',
       license='LGPL',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      tests_require = ['pytest', 'coverage', 'compressed_rtf'],
+      extras_require={'optional': ['compressed_rtf',],},
       include_package_data=True,
       zip_safe=True,
       entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages, Command
+from setuptools import setup, find_packages
 
 version = '1.3.1.dev0'
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages, Command
-import sys, os
 
 version = '1.3.1.dev0'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Python 3.5 has TLS issues on OSX at least
-envlist = py27, py36, py37, py38
+envlist = py27, py36, py37, py38, coverage
 
 [testenv]
 # install the `optional` requirements
@@ -10,6 +10,18 @@ extras =
 # this corresponds to a `pip install -e`
 usedevelop =
     true
+
+deps =
+    pytest
+    pytest-console-scripts
+
+commands =
+    pytest
+
+
+[testenv:coverage]
+basepython =
+    python3
 
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pytest-console-scripts
 
 commands =
-    pytest
+    pytest {posargs}
 
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,18 @@
 envlist = py27, py36, py37, py38
 
 [testenv]
-deps = pytest
-       pytest-console-scripts
+# install the `optional` requirements
+extras =
+    optional
+
+# this corresponds to a `pip install -e`
+usedevelop =
+    true
+
+deps =
+    pytest
+    pytest-cov
+    pytest-console-scripts
+
 commands =
-   python setup.py test
+    pytest --cov-report term-missing --cov-report html --cov


### PR DESCRIPTION
As `python setup.py test` is deprecated, tests are now run by tox and pytest.
https://setuptools.readthedocs.io/en/latest/setuptools.html#test-build-package-and-run-a-unittest-suite

While using the deprecated `test` command, the optional dependency `compressed_rtf` was provided via `tests_require`, which accompanied the mentioned `test` command.

As we now use pytest/tox, the additional requirements are provided via the `extras_require` keyword, which also offers the additional benefit that the users of the package can install the extras via `pip install tnefparse[optional]`.
if this PR gets accepted, it would be nice to document that optional installation method in the README).

The `how to run tests` section in the README.rst was updated to reflect the changes.

Also, now you can generate a coverage report already in the local development environment by invoking `tox -e coverage`. This will both generate coverage output in the terminal and in the `htmlcov` directory. This way one can check impacts on coverage even before pushing and thus waiting for the result by `codecov`.

With e.g. `tox -e py38 -- -k test_cmdline` you can now run a subset of tests in a specific environment.