### PR TITLE
Fix broken Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 install:
   - pip install -U pip
   - pip install -e .[optional]
-  - pip install pytest pytest-cov pytest-console-scripts codecov flake8
+  - pip install -U pytest pytest-cov pytest-console-scripts codecov flake8
 
 script:
   - pytest --cov


### PR DESCRIPTION
pytest 4.3.1 is installed, but pytest-cov recently started to require
pytest >= 4.6.

modified:   .travis.yml