### PR TITLE
Log exception's stack properly

### DIFF
--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -106,12 +106,9 @@ def decode_mapi(data, codepage='cp1252', starting_offset=None):
             if (num_mv_properties or 1) % 2 and attr_type in (SZMAPI_SHORT, SZMAPI_BOOLEAN):
                 offset += 2
 
-    except Exception as e:
-        import traceback
-
-        stack = traceback.format_exc()
-        logger.error('decode_mapi Exception %s' % e)
-        logger.debug(stack)
+    except Exception as exc:
+        logger.error('decode_mapi exception: %s', exc)
+        logger.debug('exception details:', exc_info=True)
 
     if starting_offset is not None:
         return (offset, attrs)


### PR DESCRIPTION
Call `logging.exception` method to get the custom message and stack trace in one call.