### PR TITLE
Use % formatting in log messages

### DIFF
--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -83,7 +83,7 @@ def tnefparse():
                 try:
                     print("    " + properties.CODE_TO_NAME[p.name])
                 except KeyError:
-                    logger.warning("Unknown MAPI Property: %s" % hex(p.name))
+                    logger.warning("Unknown MAPI Property: 0x%x", p.name)
             print("")
 
         elif args.dump:

--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -56,7 +56,7 @@ def decode_mapi(data, codepage='cp1252', starting_offset=None):
     try:
         for i in range(num_properties):
             if offset >= dataLen:
-                logger.warn("Skipping property '%i'" % i)
+                logger.warn("Skipping property %r", i)
                 continue
 
             attr_type = uint16(data, offset)

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -31,7 +31,7 @@ class TNEFObject:
         if do_checksum:
             calc_checksum = checksum(self.data)
             if calc_checksum != att_checksum:
-                logger.warning(f"Checksum: {calc_checksum} != {att_checksum}")
+                logger.warning("Checksum: %s != %s", calc_checksum, att_checksum)
         else:
             calc_checksum = att_checksum
 
@@ -137,7 +137,7 @@ class TNEFAttachment:
             pass
             # this is a WMF file of some kind
         else:
-            logger.debug("Unknown attribute name: %s" % attribute)
+            logger.debug("Unknown attribute name: %s", attribute)
 
     def __str__(self):
         return "<ATTCH:'%s'>" % self.long_filename()
@@ -315,9 +315,9 @@ class TNEF:
                     obj.data = typtime(obj.data)
                     self.msgprops.append(obj)
                 except ValueError:
-                    logger.debug("TNEF Object not a valid date: %s" % obj)
+                    logger.debug("TNEF Object not a valid date: %s", obj)
             else:
-                logger.debug("Unhandled TNEF Object: %s" % obj)
+                logger.debug("Unhandled TNEF Object: %s", obj)
 
     def has_body(self):
         return True if (self.body or self.htmlbody or self._rtfbody) else False

--- a/tnefparse/util.py
+++ b/tnefparse/util.py
@@ -77,25 +77,23 @@ def raw_mapi(dataLen, data):
     while loop <= dataLen:
         if (loop + 16) < dataLen:
             logger.debug(
-                "%2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x"
-                % (
-                    ord(data[loop]),
-                    ord(data[loop + 1]),
-                    ord(data[loop + 2]),
-                    ord(data[loop + 3]),
-                    ord(data[loop + 4]),
-                    ord(data[loop + 5]),
-                    ord(data[loop + 6]),
-                    ord(data[loop + 7]),
-                    ord(data[loop + 8]),
-                    ord(data[loop + 9]),
-                    ord(data[loop + 10]),
-                    ord(data[loop + 11]),
-                    ord(data[loop + 12]),
-                    ord(data[loop + 13]),
-                    ord(data[loop + 14]),
-                    ord(data[loop + 15]),
-                )
+                "%2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x %2.2x%2.2x",
+                ord(data[loop]),
+                ord(data[loop + 1]),
+                ord(data[loop + 2]),
+                ord(data[loop + 3]),
+                ord(data[loop + 4]),
+                ord(data[loop + 5]),
+                ord(data[loop + 6]),
+                ord(data[loop + 7]),
+                ord(data[loop + 8]),
+                ord(data[loop + 9]),
+                ord(data[loop + 10]),
+                ord(data[loop + 11]),
+                ord(data[loop + 12]),
+                ord(data[loop + 13]),
+                ord(data[loop + 14]),
+                ord(data[loop + 15]),
             )
         loop += 16
     loop -= 16
@@ -106,4 +104,4 @@ def raw_mapi(dataLen, data):
         if i != 0 and subr == 0:
             strList.append(' ')
         strList.append('%2.2x' % ord(data[loop + i]))
-    logger.debug('%s' % ''.join(strList))
+    logger.debug(''.join(strList))


### PR DESCRIPTION
Replaced all `'hello %s' % world` and `f'hello {world}'` syntax with the old standard lazy `'hello %s', world`.