### PR TITLE
put cmd-line attch zip generation support where it belongs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ tnefparse 1.4.0 (unreleased)
 - drop Python 2 support
 - drop Python 3.5 support (jugmac00)
 - add Python 3.9 support (jugmac00)
+- command-line support for zipped export of attachments (Beercow)
 
 tnefparse 1.3.1 (2020-09-30)
 =============================

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ found inside them and so on::
    -h, --help             show this help message and exit
    -o, --overview         show (possibly long) overview of TNEF file contents
    -a, --attachments      extract attachments, by default to current dir
+   -z, --zip              extract attachments into a single zip file, by default to current dir
    -p PATH, --path PATH   optional explicit path to extract attachments to
    -b, --body             extract the body to stdout
    -hb, --htmlbody        extract the HTML body to stdout

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,3 +1,4 @@
+import os
 import json
 import shutil
 import sys
@@ -21,6 +22,15 @@ def test_cmdline_attch_extract(script_runner):
     tmpdir = tempfile.mkdtemp()
     ret = script_runner.run('tnefparse', '-a', '-p', tmpdir, 'tests/examples/one-file.tnef')
     assert ret.stderr == 'Successfully wrote 1 files\n'
+    assert ret.success
+    shutil.rmtree(tmpdir)
+
+
+def test_cmdline_zip_extract(script_runner):
+    tmpdir = tempfile.mkdtemp()
+    ret = script_runner.run('tnefparse', '-z', '-p', tmpdir, 'tests/examples/one-file.tnef')
+    assert os.path.isfile(tmpdir + '/attachments.zip')
+    assert ret.stderr == 'Successfully wrote attachments.zip\n'
     assert ret.success
     shutil.rmtree(tmpdir)
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,4 +1,6 @@
 import os
+import io
+import zipfile
 import json
 import shutil
 import sys
@@ -31,6 +33,10 @@ def test_cmdline_zip_extract(script_runner):
     ret = script_runner.run('tnefparse', '-z', '-p', tmpdir, 'tests/examples/one-file.tnef')
     assert os.path.isfile(tmpdir + '/attachments.zip')
     assert ret.stderr == 'Successfully wrote attachments.zip\n'
+    with open(tmpdir + '/attachments.zip', 'rb') as zip_fp:
+        zip_stream = io.BytesIO(zip_fp.read())
+    zip_file = zipfile.ZipFile(zip_stream)
+    assert zip_file.namelist() == ['AUTHORS']
     assert ret.success
     shutil.rmtree(tmpdir)
 

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -105,6 +105,7 @@ def test_decode(tnefspec):
 
 
 def test_zip():
+    # remove this test once tnef.to_zip(bytes) is no longer supported
     with open(datadir + os.sep + 'one-file.tnef', "rb") as tfile:
         zip_data = to_zip(tfile.read())
         with tempfile.TemporaryFile() as out:

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -26,7 +26,7 @@ argument('-a', '--attachments', action='store_true',
          help='extract attachments, by default to current dir')
 
 argument('-z', '--zip', action='store_true',
-         help='extract attachments to zip file, by default to current dir')
+         help='extract attachments into a single zip file, by default to current dir')
 
 argument('-p', '--path',
          help='optional explicit path to extract attachments to')

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -101,12 +101,10 @@ def tnefparse():
             sys.exit()
 
         elif args.zip:
-            tfp.seek(0)
+            zipped = to_zip(t)
             pth = args.path.rstrip(os.sep) + os.sep if args.path else ''
-            test = tfp.read()
-            a = to_zip(test)
             with open(pth + 'attachments.zip', "wb") as afp:
-                afp.write(a)
+                afp.write(zipped)
             sys.stderr.write("Successfully wrote attachments.zip\n")
             sys.exit()
 

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from . import properties
-from .tnef import TNEF
+from .tnef import TNEF, to_zip
 
 logging.basicConfig()
 logger = logging.getLogger(__package__)
@@ -24,6 +24,9 @@ argument('-o', '--overview', action='store_true',
 
 argument('-a', '--attachments', action='store_true',
          help='extract attachments, by default to current dir')
+
+argument('-z', '--zip', action='store_true',
+         help='extract attachments to zip file, by default to current dir')
 
 argument('-p', '--path',
          help='optional explicit path to extract attachments to')
@@ -95,6 +98,16 @@ def tnefparse():
                 with open(pth + a.long_filename(), "wb") as afp:
                     afp.write(a.data)
             sys.stderr.write("Successfully wrote %i files\n" % len(t.attachments))
+            sys.exit()
+
+        elif args.zip:
+            tfp.seek(0)
+            pth = args.path.rstrip(os.sep) + os.sep if args.path else ''
+            test = tfp.read()
+            a = to_zip(test)
+            with open(pth + 'attachments.zip', "wb") as afp:
+                afp.write(a)
+            sys.stderr.write("Successfully wrote attachments.zip\n")
             sys.exit()
 
         def print_body(attr, description):

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -6,7 +6,6 @@ import warnings
 from typing import Union
 from zipfile import ZipFile, ZIP_DEFLATED, ZIP_STORED
 from io import BytesIO
-from functools import singledispatch
 from datetime import datetime
 from uuid import UUID
 
@@ -394,7 +393,8 @@ def triples(data):
 
     return sender.rstrip(b'\x00'), etype, email.rstrip(b'\x00')
 
-def to_zip(tnef:Union[TNEF, bytes], default_name='no-name', deflate=True):
+
+def to_zip(tnef: Union[TNEF, bytes], default_name='no-name', deflate=True):
     "Convert attachments in TNEF data to zip format."
 
     if isinstance(tnef, bytes):
@@ -424,4 +424,3 @@ def to_zip(tnef:Union[TNEF, bytes], default_name='no-name', deflate=True):
 
     # Return the binary data for the zip file
     return sfp.getvalue()
-


### PR DESCRIPTION
Fixed the [bad commit from a poorly-reviewed PR in 2019](https://github.com/koodaamo/tnefparse/pull/54/commits/d9f7e6477ebff3a4b999af1bf3ab5a2457cc6679) by copying over the contributed feature code manually, and adding just what's needed to satisfy checks.

~~Need to merge #81 after this.~~