### PR TITLE
Introduce type annotations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ tnefparse 1.4.0 (unreleased)
 - drop Python 2 support
 - drop Python 3.5 support (jugmac00)
 - add Python 3.9 support (jugmac00)
+- introduce using type annotations (jugmac00)
 
 tnefparse 1.3.1 (2020-09-30)
 =============================

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -47,7 +47,7 @@ argument('-d', '--dump', action="store_true", default=False,
          help="extract a json dump of the tnef contents")
 
 
-def tnefparse():
+def tnefparse() -> None:
     "command-line script"
 
     if len(sys.argv) == 1:
@@ -97,7 +97,7 @@ def tnefparse():
             sys.stderr.write("Successfully wrote %i files\n" % len(t.attachments))
             sys.exit()
 
-        def print_body(attr, description):
+        def print_body(attr: str, description: str) -> None:
             body = getattr(t, attr)
             if body is None:
                 sys.exit("No %s found" % description)

--- a/tnefparse/codepage.py
+++ b/tnefparse/codepage.py
@@ -1,3 +1,5 @@
+from typing import Optional, Union
+
 # https://docs.microsoft.com/en-us/windows/desktop/intl/code-page-identifiers
 CODEPAGE_MAP = {
     20127: 'ascii',
@@ -9,10 +11,10 @@ FALLBACK = 'cp1252'
 
 
 class Codepage:
-    def __init__(self, codepage):
+    def __init__(self, codepage: int) -> None:
         self.cp = codepage
 
-    def best_guess(self):
+    def best_guess(self) -> Optional[str]:
         if CODEPAGE_MAP.get(self.cp):
             return CODEPAGE_MAP.get(self.cp)
         elif self.cp <= 1258:  # max cpXXXX page in python
@@ -20,14 +22,14 @@ class Codepage:
         else:
             return None
 
-    def codepage(self):
+    def codepage(self) -> str:
         bg = self.best_guess()
         if bg:
             return bg
         else:
             return 'cp%d' % self.cp
 
-    def decode(self, byte_str):
+    def decode(self, byte_str: Union[str, bytes]) -> str:
         if isinstance(byte_str, bytes):
             return byte_str.decode(self.best_guess() or FALLBACK)
         else:

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -97,13 +97,13 @@ class TNEFAttachment:
         self.data = b''
 
     @property
-    def name(self):
+    def name(self) -> str:
         if isinstance(self._name, bytes):
             return self._name.decode().strip('\x00')
         else:
             return self._name.strip('\x00')
 
-    def long_filename(self):
+    def long_filename(self) -> str:
         atname = Attribute.MAPI_ATTACH_LONG_FILENAME
         name = [a.data for a in self.mapi_attrs if a.name == atname]
         if name:
@@ -326,7 +326,8 @@ class TNEF:
     def rtfbody(self):
         if self._rtfbody:
             try:
-                from compressed_rtf import decompress
+                # compressed_rtf is not typed yet
+                from compressed_rtf import decompress  # type: ignore
                 return decompress(self._rtfbody + b'\x00')
             except ImportError:
                 logger.warning("Returning compressed RTF. Install compressed_rtf to decompress")

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,13 @@ deps =
 commands =
     check-manifest
 
+[testenv:mypy]
+deps =
+    mypy
+commands =
+    # do not lint tests yet
+    mypy tnefparse {posargs}
+
 [flake8]
 # The GitHub editor is 127 chars wide.
 max-line-length = 127


### PR DESCRIPTION
You can run the type checker with `tox -e mypy`.

This is just a start.
- A lot of type annotations are still missing.
- The type checker is not yet using the strict option.
- Type annotations are not yet enforced in CI.

modified:   tnefparse/cmdline.py
modified:   tnefparse/codepage.py
modified:   tnefparse/tnef.py
modified:   tox.ini

P.S.: As there is quite some development going on, and as typing the complete project will take quite some time (at least for me), I suggest to merge this soon, as otherwise a lot of merge conflicts could arise. Python offers the concept of gradual typing, so, why no use it?