### PR TITLE
Fix for deprecation warning #98

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ tnefparse 1.4.0 (unreleased)
 - remove deprecated parseFile & raw_mapi functions
 - fix str representation for TNEF class (jugmac00)
 - prefer `getattr` over `eval` (eumiro)
+- fix `test_zip` deprecation warning for bytes (1nF0rmed)
 
 tnefparse 1.3.1 (2020-09-30)
 =============================

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import pytest
 
 from tnefparse import TNEF
 from tnefparse.tnef import to_zip
@@ -106,10 +107,11 @@ def test_decode(tnefspec):
 
 def test_zip():
     # remove this test once tnef.to_zip(bytes) is no longer supported
-    with open(datadir + os.sep + 'one-file.tnef', "rb") as tfile:
-        zip_data = to_zip(TNEF(tfile.read()))
-        with tempfile.TemporaryFile() as out:
-            out.write(zip_data)
+    with pytest.deprecated_call():
+        with open(datadir + os.sep + 'one-file.tnef', "rb") as tfile:
+            zip_data = to_zip(tfile.read())
+            with tempfile.TemporaryFile() as out:
+                out.write(zip_data)
 
 
 def to_shortname(longname):

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -107,7 +107,7 @@ def test_decode(tnefspec):
 def test_zip():
     # remove this test once tnef.to_zip(bytes) is no longer supported
     with open(datadir + os.sep + 'one-file.tnef', "rb") as tfile:
-        zip_data = to_zip(tfile.read())
+        zip_data = to_zip(TNEF(tfile.read()))
         with tempfile.TemporaryFile() as out:
             out.write(zip_data)
 


### PR DESCRIPTION
I've updated the test `test_zip` in `test_decoding.py` to create TNEF object to avoid the deprecation warning.