### PR TITLE
Run GHA CI for pull requests, once a week and on demand as well

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,11 @@
 name: Run the package tests
 
-on: [push]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: 42 0 * * 5
+  workflow_dispatch:
 
 jobs:
   build:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ tnefparse 1.4.0 (unreleased)
 - correctly handle attachments of embedded objects (jrideout)
 - add expirimental support for parsing embedded message objects (jrideout)
 - zipped output now uses long filename when possible (jrideout)
+- run GitHub Actions CI for pull requests and once a week (eumiro)
 
 tnefparse 1.3.1 (2020-09-30)
 =============================


### PR DESCRIPTION
This adds triggers to the GitHub Actions CI when:

1. push (like until now)
2. pull request, so it helps you to review PR and might replace Travis completely 
3. once a week (deliberately chosen next night, but feel free to set any other time) to get information on broken dependency even when there's no activity on the repo
4. on demand, as a special “rerun” button appears on the Actions page 