### PR TITLE
Fix tiny Python3 bits

### DIFF
--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -69,7 +69,7 @@ def test_decode(tnefspec):
     fn, key, attchs, body, objs = tnefspec
     with open(datadir + os.sep + fn, "rb") as tfile:
         t = TNEF(tfile.read())
-        assert t.key == key, "wrong key: 0x%2.2x" % t.key
+        assert t.key == key, f"wrong key: 0x{t.key:2.2x}"
 
         for m in t.mapiprops:
             assert m.__str__()
@@ -102,7 +102,7 @@ def test_decode(tnefspec):
             assert t.rtfbody[0:5] == b'{\\rtf'
 
         if objs:
-            assert objcodes(t) == objs, "wrong objs: %s" % ["0x%2.2x" % o.name for o in t.objects]
+            assert objcodes(t) == objs, "wrong objs: " + str([f"0x{o.name:2.2x}" for o in t.objects])
 
         assert t.dump(True)
         assert t.dump(False)

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -99,7 +99,7 @@ def tnefparse(argv=None) -> None:
             for a in t.attachments:
                 with open(pth + a.long_filename(), "wb") as afp:
                     afp.write(a.data)
-            sys.stderr.write("Successfully wrote %i files\n" % len(t.attachments))
+            sys.stderr.write(f"Successfully wrote {len(t.attachments)} files\n")
             sys.exit()
 
         elif args.zip:

--- a/tnefparse/cmdline.py
+++ b/tnefparse/cmdline.py
@@ -51,7 +51,7 @@ argument('-d', '--dump', action="store_true", default=False,
 
 
 def tnefparse(argv=None) -> None:
-    "command-line script"
+    """command-line script"""
 
     if argv is None:
         argv = sys.argv[1:]

--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -59,7 +59,7 @@ def decode_mapi(data, codepage='cp1252', starting_offset=None):
     try:
         for i in range(num_properties):
             if offset >= dataLen:
-                logger.warn("Skipping property %r", i)
+                logger.warning("Skipping property %r", i)
                 continue
 
             attr_type = uint16(data, offset)

--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -1,4 +1,4 @@
-"MAPI attribute definitions"
+"""MAPI attribute definitions"""
 
 import logging
 from decimal import Decimal
@@ -48,7 +48,7 @@ IMESSAGE_SIG_LEN = len(IMESSAGE_SIG)
 
 
 def decode_mapi(data, codepage='cp1252', starting_offset=None):
-    "decode MAPI types"
+    """decode MAPI types"""
 
     dataLen = len(data)
     attrs = []

--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -50,7 +50,7 @@ IMESSAGE_SIG_LEN = len(IMESSAGE_SIG)
 def decode_mapi(data, codepage='cp1252', starting_offset=None):
     """decode MAPI types"""
 
-    dataLen = len(data)
+    data_len = len(data)
     attrs = []
     offset = starting_offset or 0
     num_properties = uint32(data, offset)
@@ -58,7 +58,7 @@ def decode_mapi(data, codepage='cp1252', starting_offset=None):
 
     try:
         for i in range(num_properties):
-            if offset >= dataLen:
+            if offset >= data_len:
                 logger.warning("Skipping property %r", i)
                 continue
 
@@ -81,13 +81,13 @@ def decode_mapi(data, codepage='cp1252', starting_offset=None):
                     guid_prop = uint32(data, offset)
                     offset += 4
                 else:
-                    iidLen = uint32(data, offset)
+                    iid_len = uint32(data, offset)
                     offset += 4
-                    r = iidLen % 4
+                    r = iid_len % 4
                     if r != 0:
-                        iidLen += 4 - r
-                    guid_name = data[offset: offset + iidLen].decode('utf-16')
-                    offset += iidLen
+                        iid_len += 4 - r
+                    guid_name = data[offset: offset + iid_len].decode('utf-16')
+                    offset += iid_len
 
             num_mv_properties = None
             if MULTI_VALUE_FLAG & attr_type:

--- a/tnefparse/mapi.py
+++ b/tnefparse/mapi.py
@@ -231,4 +231,4 @@ class TNEFMAPI_Attribute:
         )
 
     def __str__(self):
-        return "<ATTR: %s>" % (self.name_str)
+        return f"<ATTR: {self.name_str}>"

--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__package__)
 
 
 class TNEFObject:
-    "a TNEF object that may contain a property and an attachment"
+    """a TNEF object that may contain a property and an attachment"""
     PTYPE_CLASS  = 0x1  # noqa: E221
     PTYPE_TIME   = 0x3  # noqa: E221
     PTYPE_STRING = 0x7  # noqa: E221
@@ -51,7 +51,7 @@ class TNEFObject:
 
 
 class TNEFAttachment:
-    "a TNEF attachment"
+    """a TNEF attachment"""
 
     SZMAPI_UNSPECIFIED = 0x0000  # MAPI Unspecified
     SZMAPI_NULL = 0x0001  # MAPI null property
@@ -155,7 +155,7 @@ class TNEFAttachment:
 
 
 class TNEF:
-    "main decoder class - start by using this"
+    """main decoder class - start by using this"""
 
     TNEF_SIGNATURE = 0x223E9F78
     LVL_MESSAGE = 0x01
@@ -398,7 +398,7 @@ def triples(data):
 
 
 def to_zip(tnef: Union[TNEF, bytes], default_name='no-name', deflate=True):
-    "Convert attachments in TNEF data to zip format."
+    """Convert attachments in TNEF data to zip format."""
 
     if isinstance(tnef, bytes):
         msg = "passing bytes to tnef.to_zip will be deprecated, pass a TNEF object instead"

--- a/tnefparse/util.py
+++ b/tnefparse/util.py
@@ -60,7 +60,7 @@ def typtime(byte_arr, offset=0):
 
 
 def bytes_to_int(byte_arr):
-    "transform multi-byte values into integers"
+    """transform multi-byte values into integers"""
     return int.from_bytes(byte_arr, byteorder="little", signed=False)
 
 


### PR DESCRIPTION
1. `log.warn` is deprecated, use `log.warning` instead
2. `"""docstrings need triple double quotes"""`
3. convert some variable names to lowercase
4. convert the last `%` strings to f-strings