### PR TITLE
ensure attachment file name

### DIFF
--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -112,7 +112,7 @@ class TNEFAttachment:
         name = [a.data for a in self.mapi_attrs if a.name == atname]
         if name:
             return name[0]
-        return self.name
+        return (self.name or 'unlabeled_attachment.bin')
 
     def add_attr(self, attribute):
         # For now, we ignore rendering/preview properties


### PR DESCRIPTION
Attached messages may have no file name.  In this case, set the
name to 'unlabeled_attachment.bin' so it visible in the listing
(option '-o') and can be extracted ('-a', '-z').  See also issue
koodaamo/tnefparse#74.

Signed-off-by: Albrecht Dreß <albrecht.dress@arcor.de>