### PR TITLE
Solve error "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x95…

### DIFF
--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -103,7 +103,7 @@ class TNEFAttachment:
     @property
     def name(self) -> str:
         if isinstance(self._name, bytes):
-            return self._name.decode().strip('\x00')
+            return self._name.decode('utf8', 'ignore').strip('\x00')
         else:
             return self._name.strip('\x00')
 


### PR DESCRIPTION
Solve error "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x95 in position 0: invalid start byte".