### PR TITLE
Revert "Solve "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x95 ...""

### DIFF
--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -103,7 +103,7 @@ class TNEFAttachment:
     @property
     def name(self) -> str:
         if isinstance(self._name, bytes):
-            return self._name.decode(encoding=self.codepage).strip('\x00')
+            return self._name.decode().strip('\x00')
         else:
             return self._name.strip('\x00')
 


### PR DESCRIPTION
Reverts koodaamo/tnefparse#122

The reverted PR will cause issues when codepage is not set, since `None` is not acceptable value for `bytes.decode`.